### PR TITLE
bump min python ver to 3.11, remove raven repo

### DIFF
--- a/.github/workflows/OnTaggedCommitPush.yml
+++ b/.github/workflows/OnTaggedCommitPush.yml
@@ -21,16 +21,11 @@ jobs:
         python3 -m cibuildwheel --output-dir dist
       env:
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.11"
         CIBW_SKIP: "*musl* pp*"
         CIBW_ARCHS_LINUX: "x86_64"        
         CIBW_BEFORE_ALL: >
           dnf install --assumeyes wget &&
-          wget $(echo "https://pkgs.dyn.su/el9/base/x86_64/raven-release.el9.noarch.rpm" | sed "s/el9/el$(rpm -q --queryformat '%{RELEASE}' rpm | grep -oP 'el\K[0-9]+')/g") &&
-          rpm -ivh raven-release*.rpm &&
-          yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo &&
-          yum clean all && 
-          yum -y install cuda-toolkit python310 python310-devel &&
           wget -c https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-lgpl-shared.tar.xz &&
           tar -xf ffmpeg-master-latest-linux64-lgpl-shared.tar.xz &&
           ls -la
@@ -91,43 +86,3 @@ jobs:
         path: dist/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  github-release:
-    name: Sign the VALI with Sigstore and upload to GitHub Release
-    needs:
-    - publish-to-pypi
-    runs-on: [ubuntu-latest]
-
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
-      with:
-        inputs: >-
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'


### PR DESCRIPTION
This PR does the following:

- Removes python3.10 version support due to `cibuildwheel` dependencies issues
- Removes automatic GitHub release publish upon submission to PyPi